### PR TITLE
build: add a check for whether user has used sudo recently or not

### DIFF
--- a/build
+++ b/build
@@ -224,6 +224,9 @@ mkdir -p build-gcc
 mkdir -p build-binutils
 
 if [[ ${TMPFS} = "yes" ]]; then
+    if [[ check_sudo ]]; then
+        echo "Please enter your password at the following prompt. It is needed to that we can mount some folders on tmpfs";
+    fi
     sudo mount -t tmpfs -o rw none build-glibc
     sudo mount -t tmpfs -o rw none build-gcc
     sudo mount -t tmpfs -o rw none build-binutils

--- a/functions
+++ b/functions
@@ -101,3 +101,7 @@ function help_menu() {
     exit
 }
 
+# Check if user needs to enter sudo password or not
+function check_sudo() {
+    sudo -n true 2>/dev/null
+}


### PR DESCRIPTION
* If they have used it recently, they won't have to enter password again
  * If they haven't, they'll get a random sudo prompt after executing the script, which might confuse them
  * With this change it now first tells the user, then prompts
  * http://imgur.com/a/MiISa
  * Thanks to https://askubuntu.com/questions/357220/how-to-check-if-sudo-password-has-been-entered-for-this-terminal-session for some help