### PR TITLE
Tell user to install binutils-dev instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ following:
 + A decent processor and RAM (i5 and 8GB of RAM or more is preferred)
 + Core developer packages
     + For Arch: the base-devel package should be enough
-    + For Ubuntu: ```sudo apt-get install flex bison ncurses-dev texinfo gcc gperf patch libtool automake g++ libncurses5-dev gawk subversion expat libexpat1-dev python-all-dev binutils-static libgcc1:i386 bc libcloog-isl-dev libcap-dev autoconf libgmp-dev build-essential gcc-multilib g++-multilib pkg-config libmpc-dev libmpfr-dev```
+    + For Ubuntu: ```sudo apt-get install flex bison ncurses-dev texinfo gcc gperf patch libtool automake g++ libncurses5-dev gawk subversion expat libexpat1-dev python-all-dev binutils-dev libgcc1:i386 bc libcloog-isl-dev libcap-dev autoconf libgmp-dev build-essential gcc-multilib g++-multilib pkg-config libmpc-dev libmpfr-dev```
 
 Once you have set up your environment, run the following:
 


### PR DESCRIPTION
apt-get on Ubuntu 17.04 is unable to locate the package "binutils-static". Use binutils-dev instead.